### PR TITLE
make common js a default export

### DIFF
--- a/index.commonjs.js
+++ b/index.commonjs.js
@@ -1,7 +1,9 @@
 var React = require('react')
 
-module.exports = React.createRef || function createRef() {
-  var ref = function(_) { ref.current = _ }
-  ref(null)
-  return ref
-}
+module.exports = {
+  default: React.createRef || function createRef() {
+    var ref = function(_) { ref.current = _ }
+    ref(null)
+    return ref
+  }
+};


### PR DESCRIPTION
Due to discrepancies, I made the exports default for common js and ejs. As tests ( jest ) use common js and frontend frameworks use ejs its not possible to have seperate imports for each. This allows both the tests and other code to access it as default exports.